### PR TITLE
Gray usability updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 .depend
 *Cint.cxx
 *DS_Store
-
+*.swp

--- a/run_analysis.sh
+++ b/run_analysis.sh
@@ -1,0 +1,31 @@
+if [$# == 3]
+then
+  Dataset=$1
+  directory=$2
+  identifier=$3
+elif [$# == 2]
+then
+  directory=$1
+  identifier=$2
+  Dataset=1
+elif [$# == 1]
+then
+  identifier=$1
+  directory="."
+  Dataset=1
+fi
+
+python scripts/selection.py  $directory/nue_${identifier}.root $Dataset "/pnfs/uboone/scratch/users/mastbaum/comparison/nue_MC_out/v06_47_00/19923250_*/prod*.root"
+python scripts/selection.py  $directory/inclusive_${identifier}.root $Dataset "/pnfs/uboone/scratch/users/mastbaum/comparison/inclusive_MC_out/v06_47_00/19923235_*/prod*.root"
+python scripts/selection.py  $directory/signal_${identifier}.root $Dataset "/pnfs/uboone/scratch/users/mastbaum/comparison/nue_signal_MC_out/v06_47_00/23371063_*/prod*.root"
+
+root -l -x -q "scripts/utils/add.C(\"nue_${identifier}.root\",\"inclusive_${identifier}.root\",\"background_${identifier}.root\")" 
+
+mkdir cov_background_${identifier}
+mkdir cov_signal_${identifier}
+
+python scripts/cov.py background_${identifier}.root -d cov_background_${identifier}
+python scripts/cov.py signal_${identifier}.root -s -d cov_signal_${identifier}
+
+python scripts/analysis/chi2.py cov_background_${identifier} cov_signal_${identifier}
+

--- a/scripts/analysis/chi2.py
+++ b/scripts/analysis/chi2.py
@@ -15,6 +15,9 @@ from numpy.core.umath_tests import inner1d
 import scipy.stats
 from matplotlib import pyplot as plt
 
+import argparse
+import time
+
 def mc_chi2(data, exp, cov, n=250000, n2=0, plot=False):
     '''Calculate a p-value with a Monte Carlo using a chi2-like statistic.
 
@@ -418,12 +421,17 @@ def plot_bin_errors(emx, em, eex, ee, ess, fcov,
 
 
 if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("background_dir")
+    parser.add_argument("signal_dir")
+    parser.add_argument("--mcmc", action="store_true")
+    args = parser.parse_args()
 
     # argv1: merged background output from cov.py
     # argv2: merged signal output from cov.py 
     # Load data from files
     enu_mx, enu_m, enu_ex, enu_e, enu_s, enu_ss, cov = \
-        load(sys.argv[1] + '/cov_all.root', sys.argv[2] + '/cov_all.root')
+        load(args.background_dir + '/cov_all.root', args.signal_dir + '/cov_all.root')
 
     eb = np.hstack((enu_m, enu_e))
     fcov = cov / np.einsum('i,j', eb, eb)
@@ -433,9 +441,9 @@ if __name__ == '__main__':
     if do_sigma_pot_plot:
         #pots = np.linspace(5e19, 6.6e20, 3)
         pots = np.linspace(5e19, 6.8e20, 10)
-        p1 = plot_sigma_v_pot(enu_m, enu_e, enu_s, fcov, pots, mc=True)[0]
+        p1 = plot_sigma_v_pot(enu_m, enu_e, enu_s, fcov, pots, mc=args.mcmc)[0]
         p1.set_label('Stat+Syst')
-        p2 = plot_sigma_v_pot(enu_m, enu_e, enu_s, fcov, pots, mc=True, syst=False)[0]
+        p2 = plot_sigma_v_pot(enu_m, enu_e, enu_s, fcov, pots, mc=args.mcmc, syst=False)[0]
         p2.set_label('Stat Only')
         plt.legend(loc='best')
         plt.savefig('sigma_v_pot.pdf')
@@ -469,11 +477,11 @@ if __name__ == '__main__':
 
         print('6.6e20 stat mc: %f' %
                significance(em, ee, es, fcov,
-               pot=66e19, syst=False, mc=True, eff_m=0.3, eff_e=0.3))
+               pot=66e19, syst=False, mc=args.mcmc, eff_m=0.3, eff_e=0.3))
 
         print('6.6e20 syst mc: %f' %
                significance(em, ee, es, fcov,
-               pot=66e19, syst=True, mc=True, eff_m=0.3, eff_e=0.3))
+               pot=66e19, syst=True, mc=args.mcmc, eff_m=0.3, eff_e=0.3))
 
         #print('5.0e19 syst mc: %f' %
         #       significance(em, ee, es, fcov,

--- a/scripts/analysis/chi2.py
+++ b/scripts/analysis/chi2.py
@@ -418,9 +418,12 @@ def plot_bin_errors(emx, em, eex, ee, ess, fcov,
 
 
 if __name__ == '__main__':
+
+    # argv1: merged background output from cov.py
+    # argv2: merged signal output from cov.py 
     # Load data from files
     enu_mx, enu_m, enu_ex, enu_e, enu_s, enu_ss, cov = \
-        load('cov_merged/cov_all.root', 'cov_sig_2/cov_all.root')
+        load(sys.argv[1] + '/cov_all.root', sys.argv[2] + '/cov_all.root')
 
     eb = np.hstack((enu_m, enu_e))
     fcov = cov / np.einsum('i,j', eb, eb)
@@ -592,7 +595,7 @@ if __name__ == '__main__':
 
         for w in reversed(wnames):
             enu_mx, enu_m, enu_ex, enu_e, enu_s, enu_ss, cov = \
-                load('cov_em_2/cov_%s.root' % w, 'cov_sig_2/cov_%s.root' % w)
+                load(sys.argv[1] + ('/cov_%s.root' % w), sys.argv[2] + ('/cov_%s.root' % w))  
 
             eb = np.hstack((enu_m, enu_e))
             fcov = cov / np.einsum('i,j', eb, eb)

--- a/scripts/cov.py
+++ b/scripts/cov.py
@@ -18,6 +18,7 @@ A. Mastbaum <mastbaum@uchicago.edu>, 2017/09
 '''
 
 import sys
+import argparse
 from glob import glob
 from ROOT import galleryfmwk
 
@@ -85,6 +86,12 @@ wg = {
     ],
 }
 
+parser = argparse.ArgumentParser("Scale input files and produce covariances")
+parser.add_argument("input_file")
+parser.add_argument("-d", "--directory", default=".")
+parser.add_argument("-s", "--signal", action="store_true")
+args = parser.parse_args()
+
 # A group with all parameters varied
 wg['all'] = []
 for v in wg.values():
@@ -101,12 +108,12 @@ sfs = 5.0e19 / 1.86828e+21  # Signal sample
 for w, ws in wg.items():
     print w
     m = galleryfmwk.TSCovariance()
-    m.SetInputFile(sys.argv[1])
+    m.SetInputFile(args.input_file)
     m.SetScaleFactorE(sfe)
     m.SetScaleFactorMu(sfm)
     for ww in ws:
         m.AddWeight(ww)
-    m.SetOutputFile('cov_%s.root' % w)
+    m.SetOutputFile(args.directory + '/cov_%s.root' % w)
     m.init()
     m.analyze()
     del m
@@ -119,7 +126,7 @@ for w in wg['all']:
     m.SetScaleFactorE(sfe)
     m.SetScaleFactorMu(sfm)
     m.AddWeight(w)
-    m.SetOutputFile('cov_%s.root' % w)
+    m.SetOutputFile(args.directory + '/cov_%s.root' % w)
     m.init()
     m.analyze()
     del m

--- a/scripts/utils/add.C
+++ b/scripts/utils/add.C
@@ -17,7 +17,8 @@
  * A. Mastbaum <mastbaum@uchicago.edu>, 2017/09/08
  */
 
-{
+void add(TString f_ccnue, TString f_bnb, TString f_out) {
+/*
   // CCnue input
   TString f_ccnue = "../sel_ccnue_take2.root";
 
@@ -26,7 +27,7 @@
 
   // Output
   TString f_out = "sel_merged_mcc8.root";
-
+*/
 
   // Read in the input files
   TFile* fe = TFile::Open(f_ccnue);

--- a/scripts/utils/run_pot.py
+++ b/scripts/utils/run_pot.py
@@ -1,0 +1,45 @@
+'''Create and print out a list of POT for each file in the input.
+
+You can then trim this and add the lines together with something
+like np.sum(np.loadtxt(file.txt)). This is a workaround since
+somehow just getting the totgoodpot branch inside ROOT doesn't
+work at all.
+
+Usage:
+
+  $ python pot.py "files*.root"
+
+The input is a set of art ROOT files.
+
+A. Mastbaum <mastbaum@uchicago.edu>, 2017/09/07
+'''
+
+import sys
+import ROOT
+
+import subprocess32
+import tempfile
+from decimal import *
+
+def main(glob):
+    tfil = tempfile.TemporaryFile()
+    proc = subprocess32.Popen(['python', 'pot.py', glob], stdout=tfil)
+    proc.wait()
+
+    tfil.seek(0)
+    s = Decimal(0)
+    for line in tfil:
+        info = line.split("*")
+        try:
+            s += Decimal(info[2].rstrip().lstrip())
+        except: 
+            pass
+    print "_____FINAL SUM______: %f" % s
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print 'Usage:', sys.argv[0], '"files*.root"'
+        sys.exit(1)
+
+    main( sys.argv[1] )
+


### PR DESCRIPTION
From email:

These are some updates to the way some the python scripts are run. I've tried to move some of the options in different scripts from being hard-coded in the scripts to being set by command line arguments. I've used the library "argparse" to do most of this. I generally like having python scripts set up this way, as I think it makes them easier to run and automate. However, if you'd rather keep these scripts the way they are I'd understand.

I've also included on this request a script--"run_pot.py"--that automatically gives the total POT of a given glob of files using "pot.py" as a subroutine.